### PR TITLE
Connection and reconnect retries

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,4 +17,6 @@ pub enum Error {
     SendCommand(#[from] tokio::sync::mpsc::error::SendError<FaktoryCommandMessage>),
     #[error(transparent)]
     BroadcastTryReceive(#[from] tokio::sync::broadcast::error::TryRecvError),
+    #[error(transparent)]
+    BroadcastSend(#[from] tokio::sync::broadcast::error::SendError<()>),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-use faktory_lib_async::Error as FaktoryLibAsyncError;
 use crate::FaktoryCommandMessage;
+use faktory_lib_async::Error as FaktoryLibAsyncError;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -17,5 +17,4 @@ pub enum Error {
     SendCommand(#[from] tokio::sync::mpsc::error::SendError<FaktoryCommandMessage>),
     #[error(transparent)]
     BroadcastTryReceive(#[from] tokio::sync::broadcast::error::TryRecvError),
-} 
-
+}


### PR DESCRIPTION
Adds a connection loop and attempts reconnect on I/O errors, informing the caller to retry their command.

Limits retry sleep to 32 seconds (2^5). Cleanly shuts down if in the reconnect/connect loop and `close` is called.