### PR TITLE
Only shutdown after the entire queue has been consumed

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,9 @@ pub enum Error {
     #[error("unexpected response: got {0}, expected {1}")]
     UnexpectedResponse(String, String),
 
+    #[error("client closed, create a new one")]
+    ClientClosed,
+
     #[error("oneshot allocated to get the faktory response for request went away: {0}")]
     ReceiveResponse(#[from] tokio::sync::oneshot::error::RecvError),
     #[error("local queue has gone away, unable to send command, this faktory_async::Client isn't recoverable anymore")]


### PR DESCRIPTION
@jhelwig @zacharyhamm Would appreciate a thorough review as I changed some parts of the code heavily and in a opinionated way, basically we had a lot of loose ends regarding shutdown that now I think are closed and now as a side effect the queue will be emptied before closing the connection.

TODO: think about a force shutdown that returns all elements from the
queue and kills the tasks?

- Forbids enqueueing new commands after shutdown is initiated
- Only stop heartbeats after the last command has been executed in faktory
- Close doesn't shutdown, it just starts the shutdown procedure (that may take indefinitely, as it waits for all commands)
- Client::drop now triggers the shutdown when the last shutdown_request_cached Arc goes away
- Add method to help identifying if shutdown is happening

<img src="https://media3.giphy.com/media/OfsbX3fVv0Sti/giphy.gif"/>